### PR TITLE
Fix syntax issue throwing a warning in chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,7 +265,7 @@ var SortableListView = React.createClass({
   },
   renderActiveDivider: function() {
     if (this.props.activeDivider) this.props.activeDivider();
-    return <View style={{height: this.state.active && this.state.active.layout.frameHeight}} />
+    return <View style={{height: this.state.active ? this.state.active.layout.frameHeight : null}} />
   },
   renderRow: function(data, section, index, highlightfn, active) {
     let Component = active ? SortRow : Row;


### PR DESCRIPTION
fixes:
![screen shot 2016-02-08 at 12 11 48 pm](https://cloud.githubusercontent.com/assets/24345/12897597/2a6f4a2c-ce5d-11e5-84d9-b73815d9f076.png)
