### PR TITLE
Track pan responder only after long press

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ var SortableListView = React.createClass({
         let vy = Math.abs(a.vy);
         let vx = Math.abs(a.vx);
 
-        return (vy ) > vx;
+        return (vy) > vx  && this.state.active;
       },
       onPanResponderMove: (evt, gestureState) => {
         gestureState.dx = 0;


### PR DESCRIPTION
Sortable list view was absorbing all gestures when row item is not selected for sorting.

E.g sortable list view was preventing my drawer in to close when there was minute vy > vx movement. When item is not selected (long press), pan responsder can ignore gestures.