### PR TITLE
Added sortRowStyle prop for style override of row being sorted

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ var SortRow = React.createClass({
   },
   render: function() {
      let handlers = this.props.panResponder.panHandlers;
-    return <Animated.View ref="view" style={[this.state.style, this.props.list.state.pan.getLayout()]}>
+    return <Animated.View ref="view" style={[this.state.style, this.props.sortRowStyle, this.props.list.state.pan.getLayout()]}>
       <View style={{opacity: .85, flex: 1}}>
         {this.props.renderRow(this.props.rowData.data, this.props.rowData.section, this.props.rowData.index, true)}
       </View>
@@ -327,7 +327,7 @@ var SortableListView = React.createClass({
             this._scrolling = true;
             this.scrollContainerHeight = e.nativeEvent.contentSize.height;
           }
-          
+
           if (this.props.onScroll) this.props.onScroll(e);
         }}
         onScrollAnimationEnd={() => this._scrolling = false}


### PR DESCRIPTION
Added a style override prop to the SortRow. This will allow people to define the look of the row being sorted which is useful if you don't want the default opacity of .2 or if you want to apply a backgroundColor when the row is moving.

Usage:
```javascript
<SortableListView
    style={{flex: 1}}
    data={data}
    order={order}
    onRowMoved={e => {
      order.splice(e.to, 0, order.splice(e.from, 1)[0]);
      this.forceUpdate();
    }}
    renderRow={row => <RowComponent data={row} />}
    sortRowStyle={{opacity: 0.90, backgroundColor: '#ccc'}}
/>
```