### PR TITLE
Splits imports between React and React Native to fix warnings in RN 0.25

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
-import React from 'react-native';
+import React from 'react';
 import TimerMixin from 'react-timer-mixin';
-
-var {
+import {
   ListView,
   LayoutAnimation,
   View,
@@ -9,7 +8,7 @@ var {
   Dimensions,
   PanResponder,
   TouchableWithoutFeedback
-} = React;
+} from 'react-native';
 
 let HEIGHT = Dimensions.get('window').height;
 var Row = React.createClass({


### PR DESCRIPTION
Splits imports between React and React Native to fix warnings in RN 0.25, ensure you're on at least RN 0.18 and have react as a dependency in your project.