### PR TITLE
Expose ListView's scrollTo method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ let {
 } = React;
 
 
-let data = { 
+let data = {
   hello: {text: 'world'},
   how: {text: 'are you'},
   test: {text: 123},
@@ -87,6 +87,10 @@ SortableListView passes through all the standard ListView properties to ListView
  - **`order`** _(Array)_  (optional) - Expects an array of keys to determine the current order of rows.
  - **`sortRowStyle`** _(Object)_ (optional) - Expects a `style` object, which is to be applied on the rows when they're being dragged.
  - **`disableSorting`** _(boolean) (optional) - When set to true, all sorting will be disabled, which will effectively make the SortableListView act like a normal ListView.
+
+## methods
+
+- **`scrollTo(...args)`** - Scrolls to a given x, y offset, either immediately or with a smooth animation. See ScrollView's scrollTo method.
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ var SortableListView = React.createClass({
 
     return this.state;
   },
-  cancel: function() { 
+  cancel: function() {
     if (!this.moved) {
       this.setState({
         active: false,
@@ -335,6 +335,9 @@ var SortableListView = React.createClass({
       />
       {this.renderActive()}
     </View>
+  },
+  scrollTo: function(...args) {
+    this.scrollResponder.scrollTo.apply(this.scrollResponder, args);
   }
 });
 


### PR DESCRIPTION
Expose Listview's scrollTo method to make the API more closely match ListView (so consumers don't need to depend on the undocumented getScrollResponder method publicly in order to scroll via code).