### PR TITLE
Fix sorting offset when the renderHeader property is set on the ListView

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ var SortableListView = React.createClass({
   checkTargetElement() {
     let scrollValue = this.scrollValue;
     let moveY = this.moveY;
-    let targetPixel = scrollValue + moveY - this.wrapperLayout.pageY;
+    let targetPixel = scrollValue + moveY - this.firstRowY;
     let i = 0;
     let x = 0;
     let row;
@@ -255,6 +255,7 @@ var SortableListView = React.createClass({
     }
 
   },
+  firstRowY: undefined,
   layoutMap: {},
   _rowRefs: {},
   handleRowActive: function(row) {
@@ -281,7 +282,7 @@ var SortableListView = React.createClass({
       active = {active: true};
     }
     let hoveringIndex = this.order[this.state.hovering];
-    return <Component
+    return (<Component
       {...this.props}
       activeDivider={this.renderActiveDivider()}
       key={index}
@@ -292,8 +293,14 @@ var SortableListView = React.createClass({
       panResponder={this.state.panResponder}
       rowData={{data, section, index}}
       onRowActive={this.handleRowActive}
-      onRowLayout={layout => this.layoutMap[index] = layout.nativeEvent.layout}
-      />
+      onRowLayout={layout => this._updateLayoutMap(index, layout.nativeEvent.layout)}
+      />);
+  },
+  _updateLayoutMap(index, layout) {
+      if (!this.firstRowY || layout.y < this.firstRowY) {
+          this.firstRowY = layout.y;
+      }
+      this.layoutMap[index] = layout;
   },
   renderActive: function() {
     if (!this.state.active) return;


### PR DESCRIPTION
Updated ListView to correctly position the placeholder when the "renderHeader" property is specified by basing the targetPixel calculation off of the Y coordinate of the first row rather than the top of the scroll container.