### PR TITLE
solves crashes caused by setTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,14 +180,24 @@ var SortableListView = React.createClass({
     }
   },
   componentDidMount: function() {
-    setTimeout(()=>{
+    let shouldUseTimeouts = typeof(this.props.shouldUseTimeouts) != 'undefined' ? this.props.shouldUseTimeouts : true;
+    if(shouldUseTimeouts){
+      setTimeout(()=>{
+        this.scrollResponder = this.refs.list.getScrollResponder();
+        this.refs.wrapper.measure((frameX, frameY, frameWidth, frameHeight, pageX, pageY) => {
+
+          let layout = {frameX, frameY, frameWidth, frameHeight, pageX, pageY};
+          this.wrapperLayout = layout;
+        });
+      }, 1);
+    } else {
       this.scrollResponder = this.refs.list.getScrollResponder();
       this.refs.wrapper.measure((frameX, frameY, frameWidth, frameHeight, pageX, pageY) => {
 
         let layout = {frameX, frameY, frameWidth, frameHeight, pageX, pageY};
         this.wrapperLayout = layout;
       });
-    }, 1);
+    }
 
   },
   scrollValue: 0,


### PR DESCRIPTION
I had a situation where setTimeout in index.js was causing app to crash, because it couldn't get methods by refs. Once I removed setTimeout I got it working all nicely. So I think it would be awesome to have an option to define if timeouts should be in use. 

My change adds a property shouldUseTimeouts and default value is true, so package continues to work the same way as until now, unless you pass in shouldUseTimeouts as false then it fallbacks to my solution for timeouts - not using them. 


Below is my situation that I had and managed to resolve via change I submit:

```
render(){
    const { isLoading } = this.props;
    return(
      isLoading ? this.renderLoading() : this.renderScreenContent()
    );
  }
```

isLoading is a value that I get via redux action and it is true, but becomes false once loading is done. In this situation while loading is happening `this.renderLoading()` returns `<Loader />` element which is my custom spinning loader, once loading is done - value of isLoading changes, rerender happens and then `this.renderScreenContent()` is in action - this function returns content view that also includes `<SortableListView />`. 

In this scenario - `setTimeout` in `react-native-sortable-listview` **_index.js_** file was causing issues. I was getting this error:
 
![screen shot 2016-11-23 at 16 56 44](https://cloud.githubusercontent.com/assets/8435507/20566542/17b030fc-b19e-11e6-8845-91d0fab6e7a2.png)
