### PR TITLE
react and react-native ought to be devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "url": "git+https://github.com/deanmcpherson/react-native-sortable-listview.git"
   },
   "dependencies": {
-    "react": "^15.4.2",
-    "react-native": "^0.41.2",
     "react-timer-mixin": "^0.13.3"
   },
   "keywords": [
@@ -34,6 +32,8 @@
   },
   "homepage": "https://github.com/deanmcpherson/react-native-sortable-listview#readme",
   "devDependencies": {
+    "react": "^15.4.2",
+    "react-native": "^0.41.2",
     "babel-jest": "^18.0.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react-native": "^1.9.1",


### PR DESCRIPTION
they were added to get jest tests working but
as dependencies they create duplicate module names when installed
in regular projects