### PR TITLE
Fixes this.refs.wrapper.measure is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,11 +187,13 @@ var SortableListView = React.createClass({
     }, 1);
   },
   measureWrapper: function() {
+    if (this.refs.wrapper) {
       this.refs.wrapper.measure((frameX, frameY, frameWidth, frameHeight, pageX, pageY) => {
 
         let layout = {frameX, frameY, frameWidth, frameHeight, pageX, pageY};
         this.wrapperLayout = layout;
       });
+    }
   },
   scrollValue: 0,
   scrollContainerHeight: HEIGHT * 1.2, //Gets calculated on scroll, but if you havent scrolled needs an initial value


### PR DESCRIPTION
I'm occasionally seeing this exception when `react-native-sortable-listview` is mounted:
![image](https://cloud.githubusercontent.com/assets/709451/23810266/b1ea71ce-0585-11e7-999b-0a9e0d0af23f.png)

This is most likely a lifecycle hook issue. Another way to fix this bug might be to ensure that `measureWrapper` is only called after `componentDidMount`, since `this.refs.wrapper` would only be undefined if `this.refs.wrapper` doesn't exist and `this.refs.wrapper` would only not exist when the component hasn't fully mounted.

This seems to work for now though.