### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ SortableListView passes through all the standard ListView properties to ListView
 
 ---
 
-###Contributions welcome!
+### Contributions welcome!
 
 ---
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
