### PR TITLE
Integrated index 0 dragging empty space patch

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ var SortableListView = React.createClass({
     if (!active && isActiveRow) {
       active = {active: true};
     }
-    let hoveringIndex = this.order[this.state.hovering] || this.state.hovering;
+    let hoveringIndex = this.order[this.state.hovering];
     return (<Component
       {...this.props}
       activeDivider={this.renderActiveDivider()}


### PR DESCRIPTION
Integrated the patch devised by @kennykswan (https://github.com/deanmcpherson/react-native-sortable-listview/issues/73#issuecomment-299681420) to fix the random empty space created when dragging to index 0 in a given list as described in https://github.com/deanmcpherson/react-native-sortable-listview/issues/73