### PR TITLE
fix panResponder

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,18 +170,21 @@ class SortableListView extends React.Component {
         return vy > vx && this.state.active
       },
       onPanResponderMove: (e, gestureState) => {
+        if (!this.state.active) return
         gestureState.dx = 0
         this.moveY = gestureState.moveY
         onPanResponderMoveCb(e, gestureState)
       },
 
       onPanResponderGrant: () => {
+        if (!this.state.active) return
         this.moved = true
         props.onMoveStart && props.onMoveStart()
         this.state.pan.setOffset(currentPanValue)
         this.state.pan.setValue(currentPanValue)
       },
       onPanResponderRelease: () => {
+        if (!this.state.active) return
         this.moved = false
         props.onMoveEnd && props.onMoveEnd()
         if (!this.state.active) {


### PR DESCRIPTION
there is something wrong with the panResponder handler, it is applied to the `ListView`, `onPanResponderMove` will be invoked even `onMoveShouldSetPanResponderCapture` returns `false`, so I add some checks for each handler

IMHO the `panRespondor` should be applied to `Row` instead of `ListView`, then there will be no the above issue, but then I encountered with some edge cases so I give up to only make a tiny patch to original repo