### PR TITLE
temporarily disable scroll when sorting to fix #76

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,8 +308,9 @@ class SortableListView extends React.Component {
         if (newScrollValue > MAX_SCROLL_VALUE) newScrollValue = MAX_SCROLL_VALUE
       }
       if (newScrollValue !== null) {
-        this.scrollValue = newScrollValue
-        this.scrollTo({ y: this.scrollValue })
+        // TODO: temporarily disable scroll when sorting to fix #76
+        // this.scrollValue = newScrollValue
+        // this.scrollTo({ y: this.scrollValue })
       }
       this.checkTargetElement()
       requestAnimationFrame(this.scrollAnimation)


### PR DESCRIPTION
Right now the scroll when sorting is buggy like #76, I'm also experiencing other issues like this, so I simply disabled it, I think it's OK that only sorting in the visible area, if you need to sorting to a invisible place, you can sorting -> scrolling -> sorting -> scrolling as a workaround

This is a workaround, I don't have enough time to resolve it properly right now, feel free to merge it or not, but IMO it's worth to be shipped, as the issue is really annoying