### PR TITLE
fix layout measure, close #101

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`renders correctly 1`] = `
 <View
-  onLayout={[Function]}
   style={
     Object {
       "flex": 1,

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -5,6 +5,8 @@ import MyComponent from '../example';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
+jest.mock('InteractionManager');
+
 test('renders correctly', () => {
   const tree = renderer.create(
     <MyComponent />

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import {
   Dimensions,
   PanResponder,
   LayoutAnimation,
+  InteractionManager,
 } from 'react-native'
 
 const HEIGHT = Dimensions.get('window').height
@@ -265,12 +266,20 @@ class SortableListView extends React.Component {
     }
   }
 
-  handleWrapperLayout = e => {
-    const layout = e.nativeEvent.layout
-    this.wrapperLayout = {
-      frameHeight: layout.height,
-      pageY: layout.y,
-    }
+  measureWrapper = () => {
+    this.refs.wrapper.measure(
+      (frameX, frameY, frameWidth, frameHeight, pageX, pageY) => {
+        const layout = {
+          frameX,
+          frameY,
+          frameWidth,
+          frameHeight,
+          pageX,
+          pageY,
+        }
+        this.wrapperLayout = layout
+      }
+    )
   }
 
   handleListLayout = e => {
@@ -436,6 +445,10 @@ class SortableListView extends React.Component {
     this.setOrder(this.props)
   }
 
+  componentDidMount() {
+    InteractionManager.runAfterInteractions(this.measureWrapper)
+  }
+
   componentWillReceiveProps(props) {
     this.setOrder(props)
   }
@@ -457,7 +470,7 @@ class SortableListView extends React.Component {
       !this.state.active && this.props.scrollEnabled !== false
 
     return (
-      <View style={{ flex: 1 }} onLayout={this.handleWrapperLayout}>
+      <View ref="wrapper" style={{ flex: 1 }}>
         <ListView
           enableEmptySections
           {...this.props}


### PR DESCRIPTION
I wrapped `measureWrapper` into `InteractionManager` to resolve a issue I mentioned in #80 , and I did that change in #80 too, but then I removed it for a simple implementation , now it seems that `onLayout` is still unreliable, see #101 

so I make this change again, ping @chetstone 