### PR TITLE
following #102, fix the Android part

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`renders correctly 1`] = `
 <View
+  collapsable={false}
   style={
     Object {
       "flex": 1,

--- a/index.js
+++ b/index.js
@@ -446,7 +446,9 @@ class SortableListView extends React.Component {
   }
 
   componentDidMount() {
-    InteractionManager.runAfterInteractions(this.measureWrapper)
+    InteractionManager.runAfterInteractions(() => {
+      setTimeout(this.measureWrapper, 0)
+    })
   }
 
   componentWillReceiveProps(props) {
@@ -470,7 +472,7 @@ class SortableListView extends React.Component {
       !this.state.active && this.props.scrollEnabled !== false
 
     return (
-      <View ref="wrapper" style={{ flex: 1 }}>
+      <View ref="wrapper" style={{ flex: 1 }} collapsable={false}>
         <ListView
           enableEmptySections
           {...this.props}


### PR DESCRIPTION
I fix the item position issue described in #101 in #102, but I only test it on iOS, I'm so sorry for my carelessness.

I spend some time to investigate the remain issue on Android, I found that `measure` always return `undefined` instead of a layout object as it does on iOS, and I found this https://github.com/facebook/react-native/issues/12966, but adding `collapsable={false}` is not enough, it works well on new RN versions, but in the `Sortable` example in this repo, all the returned layout fields are `0`, so I have to add a `setTimeout(0)` to fix it, although I don't like this idea, but sometimes we just need it.