### PR TITLE
Adding a property for disabling animated scroll. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ SortableListView passes through all the standard ListView properties to ListView
  - **`onMoveCancel`** _(Function)_ (Optional) - Register a handler to be called when move is canceled, that is the row is activated on long press and then released without any move.
  - **`activeOpacity`** _(Number)_ (Optional) - Sets opacity of an active element. Default value: `0.2`.
  - **`limitScrolling`** _(boolean) (optional) - When set to true, scrolling will be disabled when a row is active (sorting). Default is `false`.
-
+ - **`disableAnimatedScrolling`** _(boolean) (optional) - When set to true, scrolling will no longer animate. Default is `false`.
 ## methods
 
 - **`scrollTo(...args)`** - Scrolls to a given x, y offset, either immediately or with a smooth animation. See ScrollView's scrollTo method.

--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@ class SortableListView extends React.Component {
       }
       if (newScrollValue !== null && !this.props.limitScrolling) {
         this.scrollValue = newScrollValue
-        this.scrollTo({ y: this.scrollValue })
+        this.scrollTo({ y: this.scrollValue, animated: !this.props.disableAnimatedScrolling })
       }
       this.moved && this.checkTargetElement()
       requestAnimationFrame(this.scrollAnimation)


### PR DESCRIPTION
This gives the option to disable animated scrolling, which might be something users want, but more importantly this is a temp fix for this issue here, https://github.com/deanmcpherson/react-native-sortable-listview/issues/97, that will allow for people to fix the ios scrolling problem temporarily while a long term solution is addressed. 