### PR TITLE
Adds prop to moveOnPressIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+### Added
+- Prop to moveOnPressIn. LongPress delay is eliminated if moveOnPressIn is true.
+
 ## [0.2.6] - 2017-09-14
 ### Fixed
 - Issue #101

--- a/index.js
+++ b/index.js
@@ -43,9 +43,10 @@ class Row extends React.Component {
   componentDidUpdate(props) {
     // Take a shallow copy of the active data. So we can do manual comparisons of rows if needed.
     if (props.rowHasChanged) {
-      this._data = typeof props.rowData.data === 'object'
-        ? Object.assign({}, props.rowData.data)
-        : props.rowData.data
+      this._data =
+        typeof props.rowData.data === 'object'
+          ? Object.assign({}, props.rowData.data)
+          : props.rowData.data
     }
   }
 
@@ -69,11 +70,11 @@ class Row extends React.Component {
       {
         sortHandlers: {
           onLongPress: !this.props.moveOnPressIn ? this.handlePress : null,
-          onPressIn: this.props.moveOnPressIn? this.handlePress : null,
+          onPressIn: this.props.moveOnPressIn ? this.handlePress : null,
           onPressOut: this.props.list.cancel,
         },
         onLongPress: !this.props.moveOnPressIn ? this.handleLongPress : null,
-        onPressIn: this.props.moveOnPressIn? this.handlePress : null,
+        onPressIn: this.props.moveOnPressIn ? this.handlePress : null,
         onPressOut: this.props.list.cancel,
       }
     )
@@ -208,9 +209,10 @@ class SortableListView extends React.Component {
         }
         const itemHeight = this.state.active.layout.frameHeight
         const fromIndex = this.order.indexOf(this.state.active.rowData.index)
-        let toIndex = this.state.hovering === false
-          ? fromIndex
-          : Number(this.state.hovering)
+        let toIndex =
+          this.state.hovering === false
+            ? fromIndex
+            : Number(this.state.hovering)
         const up = toIndex > fromIndex
         if (up) {
           toIndex--

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ class Row extends React.Component {
     return false
   }
 
-  handleLongPress = e => {
+  handlePress = e => {
     this.refs.view.measure(
       (frameX, frameY, frameWidth, frameHeight, pageX, pageY) => {
         const layout = { frameHeight, pageY }
@@ -68,10 +68,12 @@ class Row extends React.Component {
       ),
       {
         sortHandlers: {
-          onLongPress: this.handleLongPress,
+          onLongPress: !this.props.moveOnPressIn ? this.handlePress : null,
+          onPressIn: this.props.moveOnPressIn? this.handlePress : null,
           onPressOut: this.props.list.cancel,
         },
-        onLongPress: this.handleLongPress,
+        onLongPress: !this.props.moveOnPressIn ? this.handleLongPress : null,
+        onPressIn: this.props.moveOnPressIn? this.handlePress : null,
         onPressOut: this.props.list.cancel,
       }
     )


### PR DESCRIPTION
Some of our testers were unhappy with the duration of press needed to initiate a longPress to begin reordering the list. This prop will initiate row dragging immediately when a list row (or its drag handle) is pressed.