### PR TITLE
fix issue #129 and remove useless code

### DIFF
--- a/index.js
+++ b/index.js
@@ -375,8 +375,6 @@ class SortableListView extends React.Component {
 
     if (String(i) !== this.state.hovering && i >= 0) {
       LayoutAnimation.easeInEaseOut()
-      this._previouslyHovering = this.state.hovering
-      this.__activeY = this.panY
       this.setState({
         hovering: String(i),
       })
@@ -413,7 +411,7 @@ class SortableListView extends React.Component {
     const isActiveRow =
       !active && this.state.active && this.state.active.rowData.index === index
 
-    const hoveringIndex = this.order[this.state.hovering] || this.state.hovering
+    const hoveringIndex = this.order[this.state.hovering]
     return (
       <Component
         {...this.props}


### PR DESCRIPTION
Is it affect some other cases? For what was inserted `|| this.state.hovering` before?

From my point of view, it fix mentioned issue in #129 