### PR TITLE
COURT-1777 - Fix Flickers on non-iOS Platforms

### DIFF
--- a/Sortable/example.js
+++ b/Sortable/example.js
@@ -5,6 +5,7 @@ let {
   Text,
   TouchableHighlight,
   View,
+  UIManager,
 } = require('react-native');
 
 
@@ -88,9 +89,10 @@ let RowComponent = React.createClass({
 
 let MyComponent = React.createClass({
   render: function() {
+    UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
     return (
       <View style={styles.container}>
-         <View style={{height: 64, backgroundColor: 'lightblue'} /* fake nav bar */} >
+         <View style={{height: 89, backgroundColor: 'lightblue'} /* fake nav bar */} >
            <Text style={styles.welcome} > Sortable </Text>
          </View>
       <SortableListView

--- a/index.js
+++ b/index.js
@@ -188,7 +188,12 @@ class SortableListView extends React.Component {
         this.moveY = layout.pageY + layout.frameHeight / 2 + gestureState.dy
         this.direction = gestureState.dy >= this.dy ? 'down' : 'up'
         this.dy = gestureState.dy
-        onPanResponderMoveCb(e, gestureState)
+        var { height, width } = Dimensions.get('window');
+        const adjustedListHeight = height - this.listLayout.height;
+        if (gestureState.moveY > adjustedListHeight)
+        {
+          onPanResponderMoveCb(e, gestureState)
+        }
       },
 
       onPanResponderGrant: () => {

--- a/index.js
+++ b/index.js
@@ -188,8 +188,7 @@ class SortableListView extends React.Component {
         this.moveY = layout.pageY + layout.frameHeight / 2 + gestureState.dy
         this.direction = gestureState.dy >= this.dy ? 'down' : 'up'
         this.dy = gestureState.dy
-        var { height, width } = Dimensions.get('window');
-        const adjustedListHeight = height - this.listLayout.height;
+        const adjustedListHeight = HEIGHT - this.listLayout.height;
         if (gestureState.moveY > adjustedListHeight)
         {
           onPanResponderMoveCb(e, gestureState)

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import {
   ListView,
   Dimensions,
   PanResponder,
+  Platform,
   LayoutAnimation,
   InteractionManager,
 } from 'react-native'
@@ -378,8 +379,10 @@ class SortableListView extends React.Component {
     if (!isLast) i--
 
     if (String(i) !== this.state.hovering && i >= 0) {
-      // TODO: Fix for Android and Windows
-      // LayoutAnimation.easeInEaseOut()
+      if (Platform.OS === 'ios') {
+        // TODO: Fix for Android and Windows https://github.com/facebook/react-native/issues/13207
+        // LayoutAnimation.easeInEaseOut()
+      }
       this._previouslyHovering = this.state.hovering
       this.__activeY = this.panY
       this.setState({
@@ -391,8 +394,10 @@ class SortableListView extends React.Component {
   handleRowActive = row => {
     if (this.props.disableSorting) return
     this.state.pan.setValue({ x: 0, y: 0 })
-    // TODO: Fix for Android and Windows
-    // LayoutAnimation.easeInEaseOut()
+    if (Platform.OS === 'ios') {
+      // TODO: Fix for Android and Windows https://github.com/facebook/react-native/issues/13207
+      // LayoutAnimation.easeInEaseOut()
+    }
     this.moveY = row.layout.pageY + row.layout.frameHeight / 2
     this.setState(
       {

--- a/index.js
+++ b/index.js
@@ -379,7 +379,8 @@ class SortableListView extends React.Component {
     if (!isLast) i--
 
     if (String(i) !== this.state.hovering && i >= 0) {
-      LayoutAnimation.easeInEaseOut()
+      // TODO: Fix for Android and Windows
+      // LayoutAnimation.easeInEaseOut()
       this._previouslyHovering = this.state.hovering
       this.__activeY = this.panY
       this.setState({
@@ -391,7 +392,8 @@ class SortableListView extends React.Component {
   handleRowActive = row => {
     if (this.props.disableSorting) return
     this.state.pan.setValue({ x: 0, y: 0 })
-    LayoutAnimation.easeInEaseOut()
+    // TODO: Fix for Android and Windows
+    // LayoutAnimation.easeInEaseOut()
     this.moveY = row.layout.pageY + row.layout.frameHeight / 2
     this.setState(
       {

--- a/index.js
+++ b/index.js
@@ -382,7 +382,7 @@ class SortableListView extends React.Component {
     if (String(i) !== this.state.hovering && i >= 0) {
       if (Platform.OS === 'ios') {
         // TODO: Fix for Android and Windows https://github.com/facebook/react-native/issues/13207
-        // LayoutAnimation.easeInEaseOut()
+        LayoutAnimation.easeInEaseOut()
       }
       this._previouslyHovering = this.state.hovering
       this.__activeY = this.panY
@@ -397,7 +397,7 @@ class SortableListView extends React.Component {
     this.state.pan.setValue({ x: 0, y: 0 })
     if (Platform.OS === 'ios') {
       // TODO: Fix for Android and Windows https://github.com/facebook/react-native/issues/13207
-      // LayoutAnimation.easeInEaseOut()
+      LayoutAnimation.easeInEaseOut()
     }
     this.moveY = row.layout.pageY + row.layout.frameHeight / 2
     this.setState(

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class Row extends React.Component {
   }
 
   handlePress = e => {
+    e.persist(); // suppresses an RN warning on Row press
     if (!this.refs.view) return
     this.refs.view.measure(
       (frameX, frameY, frameWidth, frameHeight, pageX, pageY) => {


### PR DESCRIPTION
This PR removes the `LayoutAnimation` method calls in order to reduce flickers on Android and Windows. Its likely to be fixed in the future, but it is causing some issues at times.
- https://github.com/deanmcpherson/react-native-sortable-listview/issues/112
- https://github.com/facebook/react-native/issues/13207
- https://facebook.github.io/react-native/docs/layoutanimation.html

It also creates an artificial ceiling for scrolls, `HEIGHT - listLayout.height`