### PR TITLE
Fix error on starting drag

### DIFF
--- a/index.js
+++ b/index.js
@@ -458,9 +458,7 @@ class SortableListView extends React.Component {
   }
 
   componentDidMount() {
-    InteractionManager.runAfterInteractions(() => {
-      this.timer = setTimeout(() => this && this.measureWrapper(), 0)
-    })
+    this.timer = setTimeout(() => this && this.measureWrapper(), 0)
   }
 
   componentWillReceiveProps(props) {


### PR DESCRIPTION
Fixes https://github.com/deanmcpherson/react-native-sortable-listview/issues/160

Error: Cannot read property 'pageY' of undefined

With fixing this, works like a charm!

Thanks for this library and thanks @lytieunuong1 for pointing out the solution !